### PR TITLE
fix: missing arg ts namespace index mass quantile

### DIFF
--- a/functime/feature_extractors.py
+++ b/functime/feature_extractors.py
@@ -2186,7 +2186,7 @@ class FeatureExtractor:
         -------
         An expression of the output
         """
-        return index_mass_quantile(self._expr)
+        return index_mass_quantile(self._expr, q)
 
     def large_standard_deviation(self, ratio: float = 0.25) -> pl.Expr:
         """


### PR DESCRIPTION
fix missing argument `q` for `index_mass_quantile` in the `ts` pl.Expr namespace