### PR TITLE
fix: update api call to current openai python format

### DIFF
--- a/functime/llm/common.py
+++ b/functime/llm/common.py
@@ -5,8 +5,8 @@ from typing import Dict, List, Mapping
 from typing_extensions import Literal
 
 try:
-    import openai
     import tiktoken
+    from openai import OpenAI
     from tenacity import retry, stop_after_attempt, wait_random_exponential
 except ModuleNotFoundError as e:
     raise ImportError(
@@ -14,11 +14,12 @@ except ModuleNotFoundError as e:
     ) from e
 
 
-openai.api_key = os.getenv("OPENAI_API_KEY")
-if openai.api_key is None:
+openai_key = os.getenv("OPENAI_API_KEY")
+if openai_key is None:
     raise ValueError(
         "OPENAI_API_KEY environment variable must be set to use the `llm` feature."
     )
+client = OpenAI(api_key=openai_key)
 
 MODEL_T = Literal["gpt-3.5-turbo", "gpt-4", "gpt-3.5-turbo-16k", "gpt-4-32k"]
 
@@ -75,10 +76,10 @@ def openai_call(
             f"Prompt exceeds token limit for model {model}. Checking with larger model..."
         )
         model = next_model
-    response = openai.ChatCompletion.create(
+    response = client.chat.completions.create(
         model=model, messages=messages, temperature=temperature, **kwargs
     )
-    return response["choices"][0]["message"]["content"].strip()
+    return response.choices[0].message.content.strip()
 
 
 def _openai_count_tokens(


### PR DESCRIPTION
The way to call the OpenAI python API has changed since the original functime LLM code was written.

If you try to use LLM now, it does nothing and says that you need to downgrade your version of the openai library to use the library.
We could alternatively enforce that the functime[llm] addon has a compatible version of openai, but I don't think it is desirable to keep an outdated version of the library when upgrading the code is so easy.

I have made some changes which fix the issue. 
These are fairly superficial.

I haven't written any tests for this, which would need some good mocks, etc. 
I 'tested' this by running the llm.iypnb notebook.
This is fixing breaking issues.